### PR TITLE
Add Duey agent with self-verification loop

### DIFF
--- a/opensunoclone-project-structure/README.md
+++ b/opensunoclone-project-structure/README.md
@@ -18,3 +18,19 @@ View your app in AI Studio: https://ai.studio/apps/drive/1TE1it6vvV4zq3juG6OAGOR
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Duey agent
+
+`Duey` is a lightweight TypeScript helper for building agents that validate their
+own work. Provide a task callback that produces an answer and a verification
+callback that checks the result. Duey will retry the task until the verification
+passes or a retry limit is hit.
+
+Example usage:
+
+```ts
+import { Duey } from './src/duey';
+
+const agent = new Duey(generate, verify);
+const result = await agent.run('Write a verse about oceans');
+```

--- a/opensunoclone-project-structure/src/duey.ts
+++ b/opensunoclone-project-structure/src/duey.ts
@@ -1,0 +1,28 @@
+export type Task = (prompt: string) => Promise<string>;
+export type Verification = (prompt: string, response: string) => Promise<boolean>;
+
+export interface DueyOptions {
+  maxRetries?: number;
+}
+
+/**
+ * Duey executes a task and verifies the response using a pluggable
+ * verification callback. It retries the task until verification succeeds or
+ * the configured retry limit is exceeded.
+ */
+export class Duey {
+  private maxRetries: number;
+
+  constructor(private task: Task, private verify: Verification, options: DueyOptions = {}) {
+    this.maxRetries = options.maxRetries ?? 3;
+  }
+
+  async run(prompt: string): Promise<string> {
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      const response = await this.task(prompt);
+      const valid = await this.verify(prompt, response);
+      if (valid) return response;
+    }
+    throw new Error(`Verification failed after ${this.maxRetries} attempts`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement Duey class for task execution with verification and retries
- document new Duey agent helper and example usage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b23bcda5688325afc29398f7308b50